### PR TITLE
Fix LaserScan to Cloud transform max range.

### DIFF
--- a/mrs_laser_mapping/src/nodes/scan_assembler_nodelet.cpp
+++ b/mrs_laser_mapping/src/nodes/scan_assembler_nodelet.cpp
@@ -162,7 +162,7 @@ void ScanAssemblerNodelet::processScans()
       }
       else
       {
-        scan_projector_.transformLaserScanToPointCloud(frame_id_, scan, cloud, tf_listener_, 35.f,
+        scan_projector_.transformLaserScanToPointCloud(frame_id_, scan, cloud, tf_listener_, scan.range_max - 0.01,
         laser_geometry::channel_option::Default);
       }
 


### PR DESCRIPTION
Previous hard-coded value of 35.0 would not work if max range in LaserScan message is lower than 35.0, as invalid readings would show up in generated cloud. See image below which shows a simulated Hokuyo UTM30LX in Gazebo with a max range of 30.0 before the fix:
![local_map_weirdness](https://cloud.githubusercontent.com/assets/205963/16853651/868e1d5c-4a0d-11e6-9598-31d383690fe9.png)

After the fix, the phantom walls disappear and mapping works.
